### PR TITLE
Fixe duplicate revenue entry for bank transfer transactions

### DIFF
--- a/plugins/gateways/uddoktapay/lib/Handler/BaseCallback.php
+++ b/plugins/gateways/uddoktapay/lib/Handler/BaseCallback.php
@@ -74,7 +74,6 @@ abstract class BaseCallback extends PluginCallback
                 exit;
             }
         } elseif ($status === PaymentStatus::PENDING) {
-            $transaction = "$paymentMethod payment of $price is Pending for Verification (Order ID: " . $invoiceId . ")";
             $cPlugin->PaymentPending($transaction);
             $returnURL = \CE_Lib::getSoftwareURL() . "/index.php?fuse=billing&pending=1&controller=invoice&view=invoice&id=" . $invoiceId;
             header("Location: " . $returnURL);


### PR DESCRIPTION
## Summary

This fixes an issue where changing a bank transfer payment status from **Pending** to **Approved** could create a duplicate revenue entry for the same transaction.

## Changes

Updated the pending payment handling by removing the duplicate transaction description assignment before calling `PaymentPending()`.

This prevents the same bank transfer payment from being recorded twice while preserving the normal pending-to-approved payment flow.

## Testing

* Tested a bank transfer payment in Pending status
* Changed the payment status from Pending to Approved
* Confirmed that only one revenue entry is created
* Confirmed that the invoice and payment status update normally
